### PR TITLE
chore(deps): bump capacitor-secure-storage to 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ store — see [CLAUDE.md](CLAUDE.md#shared-contract).
   `GET /v1/artists` and asserting the mapped artist exposes no account data
 
 ### Changed
+- `@aparajita/capacitor-secure-storage` 3.0.2 → 5.2.0, the latest release of the
+  line that depends on Capacitor 5. The plugin declares Capacitor in
+  `dependencies` rather than `peerDependencies`, so npm was installing a nested
+  `@capacitor/core@4.8.2` alongside the project's 5.7.8 and marking the plugin's
+  `@capacitor/ios@4.8.2` as `invalid`. The Android side was already fine — the
+  plugin's Gradle module compiles against `project(':capacitor-android')`, so the
+  APK used Capacitor 5 — but the JavaScript bundle shipped a second copy of
+  Capacitor, and generating the iOS platform would have produced a Podfile
+  mixing Capacitor 4 and 5. The plugin holds the access and refresh tokens, so
+  it is not a dependency to leave drifting. No application code changed: `get`,
+  `set` and `remove` keep the same signatures, the new parameters are optional,
+  and the key names are untouched. It will drift again the day Capacitor itself
+  is upgraded — that upgrade has to include this plugin in its scope from the
+  start
 - **BREAKING (contract)**: `Graffiti` gains `artist` (`{id, name} | null`). The
   API replaced `artist_id` with the artist object, so a client can label a piece
   without a second request. `null` is unknown authorship — the majority case in

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^21.2.16",
         "@angular/platform-browser-dynamic": "^21.2.16",
         "@angular/router": "^21.2.16",
-        "@aparajita/capacitor-secure-storage": "^3.0.2",
+        "@aparajita/capacitor-secure-storage": "^5.2.0",
         "@capacitor/android": "^5.7.8",
         "@capacitor/app": "5.0.6",
         "@capacitor/camera": "^5.0.10",
@@ -2438,45 +2438,28 @@
       }
     },
     "node_modules/@aparajita/capacitor-secure-storage": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@aparajita/capacitor-secure-storage/-/capacitor-secure-storage-3.0.2.tgz",
-      "integrity": "sha512-vMM6zyfqXLNe4fN1nTuU0zF60Bw5mR29JTdU5ynvSBpGe7yhBQZxcyt+94Pz7gCjfSghsEXivPcxqJp3O2qCRQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aparajita/capacitor-secure-storage/-/capacitor-secure-storage-5.2.0.tgz",
+      "integrity": "sha512-Y+b2/4825mDMDtnZlxLzj87oYcMSTezA+uWZjIZBbLgUcfiBGgUaHdw7PCZzO6PAq9tyh0DtzVpbW+TYLjA1yw==",
       "license": "MIT",
       "dependencies": {
-        "@capacitor/android": "^4.8.0",
-        "@capacitor/app": "^4.1.1",
-        "@capacitor/core": "^4.8.0",
-        "@capacitor/ios": "^4.8.0"
+        "@capacitor/android": "^5.7.3",
+        "@capacitor/app": "^5.0.7",
+        "@capacitor/core": "^5.7.3",
+        "@capacitor/ios": "^5.7.3",
+        "async-mutex": "^0.5.0"
       },
       "engines": {
         "node": ">=16.15.1"
       }
     },
-    "node_modules/@aparajita/capacitor-secure-storage/node_modules/@capacitor/android": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-4.8.2.tgz",
-      "integrity": "sha512-sWMlHJq9F/+TP6BZHoI0ztvt1kon64lu5IiJnqn80g1U/dSJdvYKhPzphwtFWmvzywQcwf25nRnaTAI/coUY+g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": "^4.8.0"
-      }
-    },
     "node_modules/@aparajita/capacitor-secure-storage/node_modules/@capacitor/app": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-4.1.1.tgz",
-      "integrity": "sha512-SJcJA1rhFQyeH6eLfUEbdKkHzAwzahJNVPNXmU88fdmXpMgM2dJGzZj1vrm6e21aQq+Z4aBVLJ2RCdj92zD7wg==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-5.0.8.tgz",
+      "integrity": "sha512-ClUPJG6Awkf5HncVCZQwLrnuugjU8TnACSJ1dKJb6QNCHv2jQzmXvB3KvTvxTZyWbh5EVvlla0qlobYyU1lb6A==",
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^4.0.0"
-      }
-    },
-    "node_modules/@aparajita/capacitor-secure-storage/node_modules/@capacitor/core": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-4.8.2.tgz",
-      "integrity": "sha512-lrDvHyQu3LWWWXkCkHATY8D3GCBIWyqnmQUiGxlTJfu9BEdmfflq+OZuDKIy4H+KYChaXM1QnymNIuWrDFXgXw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
+        "@capacitor/core": "^5.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4336,12 +4319,12 @@
       }
     },
     "node_modules/@capacitor/ios": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-4.8.2.tgz",
-      "integrity": "sha512-NBcXs6uDWcLYr9RedkhtyQckLVCPrteC9kFDSnKx3I1qQWXj7RK5g0oULCSWzQ92yxp5RsPFAfs5YdNn1JuFrQ==",
+      "version": "5.7.8",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-5.7.8.tgz",
+      "integrity": "sha512-XhGrziBnlRmCJ97LdPXOJquHPpYTwSJZIxYSXuPl7SDDuAEve8vs2wY76gLdaaFH2Z6ctdugUX+jR6VNu+ds+w==",
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^4.8.0"
+        "@capacitor/core": "^5.7.0"
       }
     },
     "node_modules/@capacitor/keyboard": {
@@ -10294,6 +10277,15 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/async-settle": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@angular/platform-browser": "^21.2.16",
     "@angular/platform-browser-dynamic": "^21.2.16",
     "@angular/router": "^21.2.16",
-    "@aparajita/capacitor-secure-storage": "^3.0.2",
+    "@aparajita/capacitor-secure-storage": "^5.2.0",
     "@capacitor/android": "^5.7.8",
     "@capacitor/app": "5.0.6",
     "@capacitor/camera": "^5.0.10",


### PR DESCRIPTION
Applies the OpenSpec change `actualizar-plugin-secure-storage` (13 of 19 tasks).

## Do not merge yet

The check that decides this change has not run: upgrading over an existing
install on a real device and confirming the stored session survives. No device
was attached to the machine that prepared this. Nothing verified here touches
the Keystore — lint, unit tests and the Angular build all run in a browser.

Pending (group 4 of the change's tasks):

1. Install the previous APK, log in, confirm the session survives a relaunch.
2. Install this APK **over it**, without uninstalling or clearing app data.
3. Confirm the session is still open and an authenticated request works.
4. Log out, confirm the next launch asks for credentials, log back in, kill the
   app from the task switcher, confirm it reopens with a session.
5. Let the 15-minute access token expire, make an authenticated request, and
   confirm `POST /api/v1/auth/refresh` shows up in the backend log with no error
   on screen.
6. Record the device model and Android version.

If the session does **not** survive step 3, stop: the storage format changed
between plugin versions and this needs a data migration, which is a different
change.

## Why

`@aparajita/capacitor-secure-storage` holds the access and refresh tokens. It
declares Capacitor in `dependencies` rather than `peerDependencies`, so npm
installed a nested `@capacitor/core@4.8.2` beside the project's 5.7.8 and marked
the plugin's `@capacitor/ios@4.8.2` as `invalid`.

The Android side was already fine — the plugin's Gradle module compiles against
`project(':capacitor-android')`, so the APK ran on Capacitor 5. What was
actually wrong: the JavaScript bundle shipped a second copy of Capacitor, and
generating the iOS platform would have produced a Podfile mixing Capacitor 4
and 5.

## Why 5.2.0 and not 8.0.0

The plugin's version line is tied to Capacitor's:

| Plugin | Requires |
|---|---|
| 3.0.2 (before) | `@capacitor/core@^4.8.0` |
| **5.2.0 (this PR)** | **`^5.7.3`** — satisfied by the project's 5.7.8 |
| 8.0.0 (latest) | `^8.0.2` |

Reaching 6, 7 or 8 means upgrading Capacitor itself, the other seven
`@capacitor/*` plugins, regenerating `android/`, and absorbing the minSdk, AGP
and Gradle jumps in Capacitor 6 and 7. That is its own change with its own
device verification — mixed in here, a failure on the device would not say
whether the plugin or the platform caused it.

## No application code changed

Signatures compared in the published `.d.ts` before installing: `get` and
`remove` are identical, `set` gains an optional fifth parameter
(`access?: KeychainAccess`, iOS only), and `get` still defaults `convertDate` to
true — no semantic change hidden behind an unchanged signature. The three calls
in `secure-token.storage.native.ts` pass none of the optional parameters, and
the key names are untouched.

`npx cap sync android` leaves no versioned diff: the generated Gradle files
reference the plugin by path, not by version.

## Verified locally

- `npm ls`: nothing `invalid`; `@capacitor/core@5.7.8` deduped on every branch.
- `npm ci --dry-run`: up to date.
- `npm run lint`: clean. `npm run test:prod`: 66/66. `npm run build:prod`: green.
- `./gradlew assembleDebug`: BUILD SUCCESSFUL.

## The debug APK grows, and that is understood

| | 3.0.2 | 5.2.0 | Delta |
|---|---|---|---|
| APK | 8 755 294 B | 8 841 561 B | +86 267 B (+0.99%) |
| `assets/public` (JS bundle) | 2 286 265 B | 2 281 904 B | −4 361 B |
| `classes*.dex` | 12 205 604 B | 12 430 692 B | +225 088 B |

The JS saving is real but small — the nested Capacitor 4 copy was already
almost entirely dropped at bundle time. The growth is native: the plugin's
Gradle module bumps its own androidx dependencies between the two versions
(`material` 1.6.1 → 1.9.0, `navigation` 2.5.1 → 2.6.0, `appcompat` 1.4.2 →
1.6.1), and a debug build does not run R8. A release build strips what is
unused.

## Known leftovers, deliberately not fixed here

- A nested `@capacitor/app@5.0.8` remains: the plugin wants `^5.0.7` while the
  root pins `"@capacitor/app": "5.0.6"` with no caret. A second copy of a small
  plugin, not of the runtime. Changing that pin is not in this change's scope.
- The plugin still declares Capacitor in `dependencies`, so it will drift again
  the day Capacitor itself is upgraded. That upgrade has to include this plugin
  in its scope from the start.
- The plugin pulls `material`, `constraintlayout` and `navigation` it does not
  need to store keys. Upstream bloat, not something this repo can fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDCHFEgvSUE67MFyb6XEN5
