### PR TITLE
build(android): stop ignoring the keystore ignore rules

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -53,9 +53,11 @@ captures/
 .idea/navEditor.xml
 
 # Keystore files
-# Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+# Never check signing material in. Losing the release keystore means the app can
+# never be updated again; committing it means anyone with repo access can sign
+# releases as us. It lives outside the tree and reaches CI as a secret.
+*.jks
+*.keystore
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild


### PR DESCRIPTION
Two characters, one live risk.

`android/.gitignore` ships with the `*.jks` and `*.keystore` rules commented out
— that is how the Android template writes them. It was harmless while `android/`
was untracked. It stopped being harmless in `5fff11d`, which checked the native
platform into the repo. A release keystore generated in the default location is
now a file git will happily offer to commit.

Signing material has no recovery path in either direction: lose it and the app
can never be updated again; commit it and anyone with repo access can sign
releases as us.

## Verified

- A `.jks` and a `.keystore` created under `android/` no longer show in
  `git status`; `git check-ignore -v` attributes both to the restored rules.
- `git ls-files android/ | grep -iE '\.jks$|\.keystore$'` returns nothing, so
  no signing material was already tracked and needs purging from history.

## Scope

This is task 4.1 of the OpenSpec change `pipeline-despliegue-swarm-y-apk`, which
requires exactly this **before** any key is generated. The rest of that group —
generating the release keystore outside the tree, storing a recoverable second
copy, loading it into CI as a masked secret — is not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDCHFEgvSUE67MFyb6XEN5