### PR TITLE
fix(auth): send the logout request authenticated, so it actually revokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ store — see [CLAUDE.md](CLAUDE.md#shared-contract).
 
 ## [Unreleased]
 
+### Fixed
+- Logging out revokes the session again — it had never revoked anything. The
+  request left without an `Authorization` header, the server answered 401, and
+  `AuthService.logout()` swallowed the error inside the `catch` that exists so a
+  dead network still clears the device. The user saw a perfectly normal logout
+  while the refresh token stayed valid on the server for another 30 days. Found
+  on a device: `POST /api/v1/auth/logout` answered 401 on every attempt while the
+  access token was still live in `personal_access_tokens`.
+
+  The cause was not the call but the flag it used. `SKIP_AUTH` meant two things
+  at once — "do not attach the token" and "do not refresh on a 401". Login,
+  register and refresh want both; logout wants only the second, and with a single
+  switch it had to pick the wrong one. Simply dropping the flag from logout would
+  have been worse than the bug: a 401 would then reach the refresh path and mint
+  a fresh token pair at the moment the user asked to have none. The flag is now
+  two — `SKIP_TOKEN` and `SKIP_REFRESH` — and logout sets only the latter
+
+### Changed
+- **Logging out now ends the session on every device of the account**, not just
+  the one you tapped it on. This is a decision, not a side effect: logging out is
+  the only control a user has when they lend their phone or think someone saw
+  their screen, and a per-device logout leaves open exactly what they meant to
+  close. Revoking too much is recoverable by signing in again; revoking too
+  little is not. The profile screen says so next to the button
+
+
 ### Added
 - `artists` bounded context: `Artist` / `ArtistRef` domain models,
   `ArtistRepository` and its HTTP implementation against the paginated

--- a/src/app/auth/infrastructure/auth.http-context.ts
+++ b/src/app/auth/infrastructure/auth.http-context.ts
@@ -1,11 +1,18 @@
 import { HttpContext, HttpContextToken } from '@angular/common/http';
 
 /**
- * Marks a request as an auth endpoint (login / refresh / logout). The
- * interceptor will NOT attach the access-token Bearer header and will NOT try
- * to refresh on a 401 for these — prevents refresh-on-refresh loops.
+ * Marks a request that must NOT carry the access-token Bearer header — the
+ * anonymous endpoints (login, register) and refresh, which authorizes itself
+ * with the refresh token it sets by hand.
  */
-export const SKIP_AUTH = new HttpContextToken<boolean>(() => false);
+export const SKIP_TOKEN = new HttpContextToken<boolean>(() => false);
+
+/**
+ * Marks a request whose 401 must NOT trigger a refresh. Every auth endpoint
+ * needs this: refreshing to refresh loops, and refreshing to log out mints a
+ * fresh pair at the exact moment the user asked to have none.
+ */
+export const SKIP_REFRESH = new HttpContextToken<boolean>(() => false);
 
 /**
  * Set on a request after the interceptor has already retried it once following
@@ -13,6 +20,16 @@ export const SKIP_AUTH = new HttpContextToken<boolean>(() => false);
  */
 export const RETRIED = new HttpContextToken<boolean>(() => false);
 
+/**
+ * The two rules used to be one flag, which forced logout to choose between
+ * sending its credential and looping on refresh. It chose wrong, and logout
+ * silently revoked nothing for as long as the flag existed. Keep them separate.
+ */
 export function skipAuth(): HttpContext {
-  return new HttpContext().set(SKIP_AUTH, true);
+  return new HttpContext().set(SKIP_TOKEN, true).set(SKIP_REFRESH, true);
+}
+
+/** Send the access token, but never refresh on a 401. Used by logout. */
+export function skipRefresh(): HttpContext {
+  return new HttpContext().set(SKIP_REFRESH, true);
 }

--- a/src/app/auth/infrastructure/auth.interceptor.spec.ts
+++ b/src/app/auth/infrastructure/auth.interceptor.spec.ts
@@ -1,0 +1,176 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+
+import { authInterceptor } from './auth.interceptor';
+import { AuthService } from '../application/auth.service';
+import { AuthRepository } from '../domain/auth.repository';
+import { SecureTokenStorage } from '../domain/token-storage';
+import { API_BASE_URL } from '../../shared/infrastructure/api.config';
+import { SanctumAuthRepository } from './sanctum-auth.repository';
+
+const BASE_URL = '/api';
+const ACCESS = '1|access-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const REFRESH = '2|refresh-token-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+/** In-memory stand-in for the OS keystore. */
+class StubTokenStorage extends SecureTokenStorage {
+  access: string | null = null;
+  refresh: string | null = null;
+
+  async getAccessToken(): Promise<string | null> {
+    return this.access;
+  }
+  async getRefreshToken(): Promise<string | null> {
+    return this.refresh;
+  }
+  async setTokens(access: string, refresh: string): Promise<void> {
+    this.access = access;
+    this.refresh = refresh;
+  }
+  async clear(): Promise<void> {
+    this.access = null;
+    this.refresh = null;
+  }
+}
+
+/**
+ * The refresh path crosses several promise hops (repository, then the secure
+ * storage write) before the retry is queued. One microtask is not enough to see
+ * it; a macrotask is, and it keeps the test free of fake timers.
+ */
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('authInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let storage: StubTokenStorage;
+  let auth: AuthService;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        { provide: API_BASE_URL, useValue: BASE_URL },
+        { provide: SecureTokenStorage, useClass: StubTokenStorage },
+        // The real repository: this test is about the request it builds.
+        { provide: AuthRepository, useClass: SanctumAuthRepository },
+        { provide: Router, useValue: { navigate: jasmine.createSpy('navigate') } },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    storage = TestBed.inject(SecureTokenStorage) as StubTokenStorage;
+    auth = TestBed.inject(AuthService);
+
+    storage.access = ACCESS;
+    storage.refresh = REFRESH;
+    await auth.hydrate();
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('attaches the access token and forces JSON on API requests', () => {
+    http.get(`${BASE_URL}/v1/graffitis`).subscribe();
+
+    const req = httpMock.expectOne(`${BASE_URL}/v1/graffitis`);
+    expect(req.request.headers.get('Authorization')).toBe(`Bearer ${ACCESS}`);
+    expect(req.request.headers.get('Accept')).toBe('application/json');
+    req.flush({});
+  });
+
+  it('leaves requests outside the API alone', () => {
+    http.get('https://media.example.test/photo.jpg').subscribe();
+
+    const req = httpMock.expectOne('https://media.example.test/photo.jpg');
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush({});
+  });
+
+  // The defect this change exists for: logout used the same context as login and
+  // refresh, so the interceptor skipped the Authorization header entirely. The
+  // server answered 401, AuthService swallowed it, and nothing was ever revoked.
+  it('sends logout authenticated', async () => {
+    const done = auth.logout();
+
+    const req = httpMock.expectOne(`${BASE_URL}/v1/auth/logout`);
+    expect(req.request.headers.get('Authorization')).toBe(`Bearer ${ACCESS}`);
+    req.flush({ message: 'Tokens revoked' });
+    await done;
+  });
+
+  it('does not refresh when logout is rejected', async () => {
+    const done = auth.logout();
+
+    httpMock
+      .expectOne(`${BASE_URL}/v1/auth/logout`)
+      .flush({ message: 'Unauthenticated.' }, { status: 401, statusText: 'Unauthorized' });
+
+    // Renewing the session in order to end it would hand back a fresh pair.
+    httpMock.expectNone(`${BASE_URL}/v1/auth/refresh`);
+    await done;
+    expect(await storage.getAccessToken()).toBeNull();
+  });
+
+  it('keeps login anonymous', async () => {
+    const pending = auth.login({ email: 'jane@example.test', password: 'secret123' });
+
+    const req = httpMock.expectOne(`${BASE_URL}/v1/auth/login`);
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush({
+      data: {
+        access_token: ' 3|new-access',
+        refresh_token: '4|new-refresh',
+        token_type: 'Bearer',
+        expires_in: 900,
+      },
+    });
+    await pending;
+  });
+
+  it('refreshes once on a 401 and retries the original request', async () => {
+    const seen: unknown[] = [];
+    http.get(`${BASE_URL}/v1/graffitis`).subscribe((r) => seen.push(r));
+
+    httpMock
+      .expectOne(`${BASE_URL}/v1/graffitis`)
+      .flush({ message: 'Unauthenticated.' }, { status: 401, statusText: 'Unauthorized' });
+
+    const refresh = httpMock.expectOne(`${BASE_URL}/v1/auth/refresh`);
+    expect(refresh.request.headers.get('Authorization')).toBe(`Bearer ${REFRESH}`);
+    refresh.flush({
+      data: {
+        access_token: '5|rotated-access',
+        refresh_token: '6|rotated-refresh',
+        token_type: 'Bearer',
+        expires_in: 900,
+      },
+    });
+
+    await settle();
+    const retried = httpMock.expectOne(`${BASE_URL}/v1/graffitis`);
+    expect(retried.request.headers.get('Authorization')).toBe('Bearer 5|rotated-access');
+    retried.flush({ ok: true });
+  });
+
+  it('does not chain a second refresh when the refresh itself fails', async () => {
+    http.get(`${BASE_URL}/v1/graffitis`).subscribe({ error: () => undefined });
+
+    httpMock
+      .expectOne(`${BASE_URL}/v1/graffitis`)
+      .flush({ message: 'Unauthenticated.' }, { status: 401, statusText: 'Unauthorized' });
+
+    httpMock
+      .expectOne(`${BASE_URL}/v1/auth/refresh`)
+      .flush({ message: 'Unauthenticated.' }, { status: 401, statusText: 'Unauthorized' });
+
+    await settle();
+    httpMock.expectNone(`${BASE_URL}/v1/auth/refresh`);
+  });
+});

--- a/src/app/auth/infrastructure/auth.interceptor.ts
+++ b/src/app/auth/infrastructure/auth.interceptor.ts
@@ -9,7 +9,7 @@ import {
 import { Observable, catchError, from, switchMap, throwError } from 'rxjs';
 import { AuthService } from '../application/auth.service';
 import { API_BASE_URL } from '../../shared/infrastructure/api.config';
-import { RETRIED, SKIP_AUTH } from './auth.http-context';
+import { RETRIED, SKIP_REFRESH, SKIP_TOKEN } from './auth.http-context';
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const auth = inject(AuthService);
@@ -24,8 +24,11 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
   // instead of returning JSON (known bug).
   let apiReq = req.clone({ setHeaders: { Accept: 'application/json' } });
 
-  const isAuthEndpoint = apiReq.context.get(SKIP_AUTH);
-  if (!isAuthEndpoint) {
+  // Two separate decisions: whether to attach the token, and whether a 401 may
+  // be recovered by refreshing. Logout wants the first and not the second.
+  const skipToken = apiReq.context.get(SKIP_TOKEN);
+  const skipRefreshOn401 = apiReq.context.get(SKIP_REFRESH);
+  if (!skipToken) {
     const token = auth.accessToken();
     if (token) {
       apiReq = apiReq.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
@@ -37,9 +40,9 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
       if (!(err instanceof HttpErrorResponse)) {
         return throwError(() => err);
       }
-      // Auth endpoints (login/refresh/logout) handle their own failures (422
-      // bad-creds, refresh 401, etc.).
-      if (isAuthEndpoint) {
+      // Auth endpoints (login/register/refresh/logout) handle their own failures
+      // (422 bad-creds, refresh 401, logout on an already-dead token, etc.).
+      if (skipRefreshOn401) {
         return throwError(() => err);
       }
       // 403 = token lacks the required ability (dead/invalid session). Not

--- a/src/app/auth/infrastructure/sanctum-auth.repository.ts
+++ b/src/app/auth/infrastructure/sanctum-auth.repository.ts
@@ -11,7 +11,7 @@ import {
   Wrapped,
 } from '../domain/auth.model';
 import { API_BASE_URL } from '../../shared/infrastructure/api.config';
-import { skipAuth } from './auth.http-context';
+import { skipAuth, skipRefresh } from './auth.http-context';
 
 // Confirmed routes (Laravel /api/v1). `Accept: application/json` is forced
 // globally by authInterceptor — without it the API 302-redirects instead of
@@ -36,10 +36,12 @@ export class SanctumAuthRepository extends AuthRepository {
   }
 
   logout(): Promise<void> {
-    // Bearer (access token) attached by the interceptor; skipAuth so a 401 here
-    // does not trigger a refresh attempt.
+    // Authenticated on purpose: the server needs the access token to know which
+    // account to revoke. skipRefresh (not skipAuth) so the Bearer header is
+    // attached while a 401 still does not trigger a refresh — renewing the
+    // session in order to end it would mint a fresh pair and revoke nothing.
     return firstValueFrom(
-      this.http.post<void>(`${this.baseUrl}${LOGOUT_PATH}`, {}, { context: skipAuth() })
+      this.http.post<void>(`${this.baseUrl}${LOGOUT_PATH}`, {}, { context: skipRefresh() })
     );
   }
 

--- a/src/app/auth/presentation/profile/profile.page.html
+++ b/src/app/auth/presentation/profile/profile.page.html
@@ -14,4 +14,12 @@
   <ion-button expand="block" color="medium" (click)="logout()">
     Cerrar sesión
   </ion-button>
+  <!--
+    The scope is deliberate, so it has to be readable before the tap and without
+    opening anything: logging out revokes every token of the account. Without
+    this line, "my other device logged itself out" reads as a bug.
+  -->
+  <ion-note class="gm-logout-scope">
+    Se cerrará la sesión en todos tus dispositivos.
+  </ion-note>
 </ion-content>

--- a/src/app/auth/presentation/profile/profile.page.ts
+++ b/src/app/auth/presentation/profile/profile.page.ts
@@ -1,7 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import {
-  IonHeader, IonToolbar, IonTitle, IonContent, IonButton, IonText,
+  IonHeader, IonToolbar, IonTitle, IonContent, IonButton, IonText, IonNote,
 } from '@ionic/angular/standalone';
 import { AuthService } from '../../application/auth.service';
 
@@ -9,7 +9,17 @@ import { AuthService } from '../../application/auth.service';
   selector: 'gm-profile',
   templateUrl: './profile.page.html',
   standalone: true,
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent, IonButton, IonText],
+  imports: [IonHeader, IonToolbar, IonTitle, IonContent, IonButton, IonText, IonNote],
+  styles: [
+    `
+      .gm-logout-scope {
+        display: block;
+        margin-top: 0.5rem;
+        text-align: center;
+        font-size: 0.85rem;
+      }
+    `,
+  ],
 })
 export class ProfilePage {
   readonly authService = inject(AuthService);


### PR DESCRIPTION
Logging out revoked nothing. Not "sometimes", not "on flaky networks" — never.

The request left without an `Authorization` header, the server answered 401, and
`AuthService.logout()` swallowed it inside the `catch` that exists so a dead
network still clears the device. The user saw a perfectly normal logout while the
refresh token stayed valid on the server for another 30 days. The one control
someone has when they lend their phone, or think a screen was seen, did nothing.

Found on an OPPO CPH1941 running Android 11, verifying a different change:

```
21:29:45 "POST /api/v1/auth/logout HTTP/1.1" 401
21:31:55 "POST /api/v1/auth/logout HTTP/1.1" 401
21:34:18 "POST /api/v1/auth/logout HTTP/1.1" 401
```

The access token was live in `personal_access_tokens` at each attempt.
Reproduced with both 3.0.2 and 5.2.0 of the secure storage plugin, so it
predates that upgrade.

## The fix is not the one-liner

`SKIP_AUTH` meant two things at once: "do not attach the token" and "do not
refresh on a 401". Login, register and refresh want both. Logout wants only the
second, and with a single switch it had to pick the wrong one.

**Dropping the flag from logout would have been worse than the bug.** The 401
would then reach `handle401`, and the app would refresh — minting a fresh token
pair at the exact moment the user asked to have none. So the flag becomes two,
`SKIP_TOKEN` and `SKIP_REFRESH`, and logout sets only the latter.

The comment on `logout()` claimed "Bearer attached by the interceptor" while the
flag on the same line prevented exactly that. It now describes what the code does.

## Scope is a decision, and it is now visible

Logging out ends the session on **every device of the account**. That is what
`LogoutController` already did; what is new is that it is chosen rather than
inherited, and that the profile screen says so next to the button.

Revoking too much is recoverable by signing in again. Revoking too little is not.

## Tests

`auth.interceptor.spec.ts` did not exist. The logout header test was written
first and failed as it should:

```
Expected null to be 'Bearer 1|access-token-…'
```

It also pins what must not regress around it, since this touches the interceptor
every request goes through: refresh once on a 401 and retry the original, no
second refresh when the refresh itself fails, no refresh at all on a logout 401,
and login staying anonymous. 73/73 green.

## Verified on the device

- `POST /api/v1/auth/logout` → **200**, where it was 401 before.
- Token rows for that account disappear: 8 → 4.
- A second session of the same account, opened with `curl` from the laptop,
  starts answering 401 the moment the phone logs out.

Backend side is a separate PR: `LogoutController` was always correct, it just had
no tests and no written decision about its scope.

Applies the OpenSpec change `revocar-la-sesion-al-cerrarla`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDCHFEgvSUE67MFyb6XEN5
