### PR TITLE
test(auth): cover the session flow, and pin one place it diverges from spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ store — see [CLAUDE.md](CLAUDE.md#shared-contract).
 
 ## [Unreleased]
 
+### Added
+- Coverage for the session flow, which had none: `auth.service.spec.ts` and
+  `token-storage.spec.ts` are new, and `auth.interceptor.spec.ts` grew the cases
+  it was missing. Between them they pin the parts that are easy to break without
+  noticing — the rotated refresh token is the one that gets stored, three
+  requests expiring together spend a single refresh, a 403 tears the session down
+  without renewing, logging out clears the device even when the server call
+  fails, and no token ever reaches `localStorage`, `sessionStorage` or cookies
+
+  One test is deliberately **pending** rather than passing or deleted: the client
+  is specified to log out when a request retried after a refresh is rejected
+  again, and it does not. `handle401` calls `next(retried)` from inside the
+  observable the outer `catchError` returns, and RxJS does not route those errors
+  back into that `catchError`, so the `RETRIED` branch is unreachable. The loop
+  is still broken — no second refresh, and the error reaches the caller — but the
+  dead session stays in place while every request answers 401. Recorded, not
+  fixed: this work adds coverage, it does not change behaviour
+
+
 ### Fixed
 - Logging out revokes the session again — it had never revoked anything. The
   request left without an `Authorization` header, the server answered 401, and

--- a/src/app/auth/application/auth.service.spec.ts
+++ b/src/app/auth/application/auth.service.spec.ts
@@ -1,0 +1,225 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+
+import { AuthService } from './auth.service';
+import { AuthRepository } from '../domain/auth.repository';
+import { SecureTokenStorage } from '../domain/token-storage';
+import { SanctumAuthRepository } from '../infrastructure/sanctum-auth.repository';
+import { authInterceptor } from '../infrastructure/auth.interceptor';
+import { API_BASE_URL } from '../../shared/infrastructure/api.config';
+
+const BASE_URL = '/api';
+const ACCESS = '1|access-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const REFRESH = '2|refresh-token-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const NEW_ACCESS = '3|rotated-access-cccccccccccccccccccccccccccc';
+const NEW_REFRESH = '4|rotated-refresh-dddddddddddddddddddddddddd';
+
+/** In-memory stand-in for the OS keystore. */
+class StubTokenStorage extends SecureTokenStorage {
+  access: string | null = null;
+  refresh: string | null = null;
+  clearCount = 0;
+
+  async getAccessToken(): Promise<string | null> {
+    return this.access;
+  }
+  async getRefreshToken(): Promise<string | null> {
+    return this.refresh;
+  }
+  async setTokens(access: string, refresh: string): Promise<void> {
+    this.access = access;
+    this.refresh = refresh;
+  }
+  async clear(): Promise<void> {
+    this.access = null;
+    this.refresh = null;
+    this.clearCount++;
+  }
+}
+
+const pair = (access: string, refresh: string) => ({
+  data: { access_token: access, refresh_token: refresh, token_type: 'Bearer', expires_in: 900 },
+});
+
+/** The refresh path crosses several promise hops before settling. */
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('AuthService', () => {
+  let auth: AuthService;
+  let httpMock: HttpTestingController;
+  let storage: StubTokenStorage;
+  let router: { navigate: jasmine.Spy };
+
+  beforeEach(() => {
+    router = { navigate: jasmine.createSpy('navigate') };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        { provide: API_BASE_URL, useValue: BASE_URL },
+        { provide: SecureTokenStorage, useClass: StubTokenStorage },
+        { provide: AuthRepository, useClass: SanctumAuthRepository },
+        { provide: Router, useValue: router },
+      ],
+    });
+
+    auth = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+    storage = TestBed.inject(SecureTokenStorage) as StubTokenStorage;
+  });
+
+  afterEach(() => httpMock.verify());
+
+  async function withSession(): Promise<void> {
+    storage.access = ACCESS;
+    storage.refresh = REFRESH;
+    await auth.hydrate();
+  }
+
+  describe('hydrate', () => {
+    it('reports an authenticated session when the store holds one', async () => {
+      await withSession();
+      expect(auth.isAuthenticated()).toBeTrue();
+    });
+
+    it('reports no session when the store is empty', async () => {
+      await auth.hydrate();
+      expect(auth.isAuthenticated()).toBeFalse();
+      expect(auth.accessToken()).toBeNull();
+    });
+  });
+
+  describe('refresh', () => {
+    it('stores the rotated pair, not the one it sent', async () => {
+      await withSession();
+
+      const token = auth.refresh();
+      const req = httpMock.expectOne(`${BASE_URL}/v1/auth/refresh`);
+      expect(req.request.headers.get('Authorization')).toBe(`Bearer ${REFRESH}`);
+      req.flush(pair(NEW_ACCESS, NEW_REFRESH));
+
+      expect(await token).toBe(NEW_ACCESS);
+      // Keeping the old refresh token is what kills the session on the next
+      // renewal, and it looks identical to success until then.
+      expect(await storage.getRefreshToken()).toBe(NEW_REFRESH);
+      expect(await storage.getAccessToken()).toBe(NEW_ACCESS);
+    });
+
+    it('spends one refresh token for concurrent callers', async () => {
+      await withSession();
+
+      const all = Promise.all([auth.refresh(), auth.refresh(), auth.refresh()]);
+
+      // Rotation is why this matters: a second in-flight refresh would present a
+      // token the first one just revoked, and log out a valid session.
+      const reqs = httpMock.match(`${BASE_URL}/v1/auth/refresh`);
+      expect(reqs.length).toBe(1);
+      reqs[0].flush(pair(NEW_ACCESS, NEW_REFRESH));
+
+      expect(await all).toEqual([NEW_ACCESS, NEW_ACCESS, NEW_ACCESS]);
+    });
+
+    it('allows a later refresh once the shared one has settled', async () => {
+      await withSession();
+
+      const first = auth.refresh();
+      httpMock.expectOne(`${BASE_URL}/v1/auth/refresh`).flush(pair(NEW_ACCESS, NEW_REFRESH));
+      await first;
+
+      const second = auth.refresh();
+      const req = httpMock.expectOne(`${BASE_URL}/v1/auth/refresh`);
+      expect(req.request.headers.get('Authorization')).toBe(`Bearer ${NEW_REFRESH}`);
+      req.flush(pair('5|third-access', '6|third-refresh'));
+      expect(await second).toBe('5|third-access');
+    });
+
+    it('is not left blocked after a failed refresh', async () => {
+      await withSession();
+
+      const first = auth.refresh();
+      httpMock
+        .expectOne(`${BASE_URL}/v1/auth/refresh`)
+        .flush({ message: 'Unauthenticated.' }, { status: 401, statusText: 'Unauthorized' });
+      expect(await first).toBeNull();
+
+      // The session is gone, so a later refresh must not call the endpoint —
+      // but it must not hang on the previous promise either.
+      await withSession();
+      const second = auth.refresh();
+      httpMock.expectOne(`${BASE_URL}/v1/auth/refresh`).flush(pair(NEW_ACCESS, NEW_REFRESH));
+      expect(await second).toBe(NEW_ACCESS);
+    });
+
+    it('tears the session down when the refresh is rejected', async () => {
+      await withSession();
+
+      const token = auth.refresh();
+      httpMock
+        .expectOne(`${BASE_URL}/v1/auth/refresh`)
+        .flush({ message: 'Unauthenticated.' }, { status: 401, statusText: 'Unauthorized' });
+
+      expect(await token).toBeNull();
+      expect(await storage.getAccessToken()).toBeNull();
+      expect(await storage.getRefreshToken()).toBeNull();
+      expect(auth.isAuthenticated()).toBeFalse();
+      expect(router.navigate).toHaveBeenCalledWith(['/auth/login']);
+    });
+
+    it('does not call the endpoint when there is no refresh token', async () => {
+      await auth.hydrate();
+
+      expect(await auth.refresh()).toBeNull();
+      httpMock.expectNone(`${BASE_URL}/v1/auth/refresh`);
+      expect(router.navigate).toHaveBeenCalledWith(['/auth/login']);
+    });
+  });
+
+  describe('logout', () => {
+    it('clears the device even when the server call fails', async () => {
+      await withSession();
+
+      const done = auth.logout();
+      httpMock
+        .expectOne(`${BASE_URL}/v1/auth/logout`)
+        .flush({ message: 'Service Unavailable' }, { status: 503, statusText: 'Unavailable' });
+
+      // Leaving the tokens on the device because the network was down turns an
+      // explicit logout into a session that is still open.
+      await expectAsync(done).toBeResolved();
+      expect(await storage.getAccessToken()).toBeNull();
+      expect(await storage.getRefreshToken()).toBeNull();
+      expect(router.navigate).toHaveBeenCalledWith(['/auth/login']);
+    });
+  });
+
+  describe('login', () => {
+    it('stores the pair it receives', async () => {
+      const done = auth.login({ email: 'jane@example.test', password: 'secret123' });
+
+      httpMock.expectOne(`${BASE_URL}/v1/auth/login`).flush(pair(ACCESS, REFRESH));
+      await done;
+
+      expect(await storage.getAccessToken()).toBe(ACCESS);
+      expect(auth.isAuthenticated()).toBeTrue();
+    });
+
+    it('propagates bad credentials to the caller', async () => {
+      const done = auth.login({ email: 'jane@example.test', password: 'wrong' });
+
+      httpMock.expectOne(`${BASE_URL}/v1/auth/login`).flush(
+        { message: 'The provided credentials are incorrect.', errors: { email: ['bad'] } },
+        { status: 422, statusText: 'Unprocessable Content' }
+      );
+
+      await expectAsync(done).toBeRejected();
+      expect(auth.isAuthenticated()).toBeFalse();
+      await settle();
+    });
+  });
+});

--- a/src/app/auth/domain/token-storage.spec.ts
+++ b/src/app/auth/domain/token-storage.spec.ts
@@ -1,0 +1,66 @@
+import { SecureTokenStorage } from './token-storage';
+import { SecureTokenStorageWeb } from '../infrastructure/secure-token.storage.web';
+
+const ACCESS = '1|access-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const REFRESH = '2|refresh-token-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+/**
+ * The contract every implementation of the port has to honour, native or not.
+ * The device-backed one cannot run here — there is no bridge in a browser — so
+ * what CI can check is the shape of the contract and that nothing reaches the
+ * page's own storage. The Keystore itself is verified by hand on a device.
+ */
+describe('SecureTokenStorage contract', () => {
+  let storage: SecureTokenStorage;
+
+  beforeEach(() => {
+    storage = new SecureTokenStorageWeb();
+  });
+
+  it('returns nothing before anything is stored', async () => {
+    expect(await storage.getAccessToken()).toBeNull();
+    expect(await storage.getRefreshToken()).toBeNull();
+  });
+
+  it('returns what was stored', async () => {
+    await storage.setTokens(ACCESS, REFRESH);
+
+    expect(await storage.getAccessToken()).toBe(ACCESS);
+    expect(await storage.getRefreshToken()).toBe(REFRESH);
+  });
+
+  it('returns nothing after clear', async () => {
+    await storage.setTokens(ACCESS, REFRESH);
+    await storage.clear();
+
+    expect(await storage.getAccessToken()).toBeNull();
+    expect(await storage.getRefreshToken()).toBeNull();
+  });
+
+  it('does not survive a new instance off the device', async () => {
+    await storage.setTokens(ACCESS, REFRESH);
+
+    // Specified behaviour, not a defect: with no OS keystore the tokens live in
+    // memory only, so reloading the page costs the session. Persisting them in
+    // browser storage would put them within reach of any injected script.
+    expect(await new SecureTokenStorageWeb().getAccessToken()).toBeNull();
+  });
+
+  it('leaves no token anywhere the page can read', async () => {
+    await storage.setTokens(ACCESS, REFRESH);
+
+    // Searching every key rather than the ones we know about: the failure that
+    // matters is the one written under a name nobody anticipated.
+    const holds = (store: Storage): boolean =>
+      Object.keys(store).some((key) => {
+        const value = store.getItem(key) ?? '';
+
+        return value.includes(ACCESS) || value.includes(REFRESH);
+      });
+
+    expect(holds(localStorage)).toBeFalse();
+    expect(holds(sessionStorage)).toBeFalse();
+    expect(document.cookie.includes(ACCESS)).toBeFalse();
+    expect(document.cookie.includes(REFRESH)).toBeFalse();
+  });
+});

--- a/src/app/auth/infrastructure/auth.interceptor.spec.ts
+++ b/src/app/auth/infrastructure/auth.interceptor.spec.ts
@@ -159,6 +159,91 @@ describe('authInterceptor', () => {
     retried.flush({ ok: true });
   });
 
+  it('tears the session down on a 403 without trying to refresh', async () => {
+    http.get(`${BASE_URL}/v1/graffitis`).subscribe({ error: () => undefined });
+
+    httpMock
+      .expectOne(`${BASE_URL}/v1/graffitis`)
+      .flush({ message: 'Forbidden.' }, { status: 403, statusText: 'Forbidden' });
+
+    // A credential lacking the required ability does not gain it by renewing.
+    httpMock.expectNone(`${BASE_URL}/v1/auth/refresh`);
+    await settle();
+    expect(await storage.getAccessToken()).toBeNull();
+  });
+
+  it('does not refresh a second time when the retry is also rejected', async () => {
+    let reachedCaller = false;
+    http.get(`${BASE_URL}/v1/graffitis`).subscribe({ error: () => (reachedCaller = true) });
+
+    httpMock
+      .expectOne(`${BASE_URL}/v1/graffitis`)
+      .flush({ message: 'Unauthenticated.' }, { status: 401, statusText: 'Unauthorized' });
+
+    httpMock.expectOne(`${BASE_URL}/v1/auth/refresh`).flush({
+      data: {
+        access_token: '7|second-access',
+        refresh_token: '8|second-refresh',
+        token_type: 'Bearer',
+        expires_in: 900,
+      },
+    });
+
+    await settle();
+    httpMock
+      .expectOne(`${BASE_URL}/v1/graffitis`)
+      .flush({ message: 'Unauthenticated.' }, { status: 401, statusText: 'Unauthorized' });
+
+    // The loop is broken, which is the half that protects the user from a frozen
+    // app: no second refresh, and the error reaches the caller.
+    await settle();
+    httpMock.expectNone(`${BASE_URL}/v1/auth/refresh`);
+    expect(reachedCaller).toBeTrue();
+  });
+
+  it('should tear the session down when the retry is also rejected', () => {
+    pending(
+      'Diverges from identity/renovacion-de-sesion, scenario "El reintento vuelve a fallar", ' +
+        'which requires the client to log out at this point. It does not: handle401 calls ' +
+        'next(retried) from inside the observable the outer catchError returns, and RxJS does ' +
+        'not route those errors back into that catchError. The RETRIED branch is therefore ' +
+        'unreachable and the session is left in place while every request 401s. Recorded as a ' +
+        'divergence rather than fixed here: this change adds coverage, it does not change ' +
+        'behaviour.'
+    );
+  });
+
+  it('shares one refresh between requests that expire together', async () => {
+    const urls = ['/v1/graffitis', '/v1/artists', '/v1/categories'];
+    urls.forEach((u) => http.get(`${BASE_URL}${u}`).subscribe({ error: () => undefined }));
+
+    urls.forEach((u) =>
+      httpMock
+        .expectOne(`${BASE_URL}${u}`)
+        .flush({ message: 'Unauthenticated.' }, { status: 401, statusText: 'Unauthorized' })
+    );
+
+    // Three parallel refreshes would present a token the first one revoked, and
+    // log out a session that was perfectly valid.
+    const refreshes = httpMock.match(`${BASE_URL}/v1/auth/refresh`);
+    expect(refreshes.length).toBe(1);
+    refreshes[0].flush({
+      data: {
+        access_token: '9|shared-access',
+        refresh_token: '10|shared-refresh',
+        token_type: 'Bearer',
+        expires_in: 900,
+      },
+    });
+
+    await settle();
+    urls.forEach((u) => {
+      const retried = httpMock.expectOne(`${BASE_URL}${u}`);
+      expect(retried.request.headers.get('Authorization')).toBe('Bearer 9|shared-access');
+      retried.flush({ ok: true });
+    });
+  });
+
   it('does not chain a second refresh when the refresh itself fails', async () => {
     http.get(`${BASE_URL}/v1/graffitis`).subscribe({ error: () => undefined });
 


### PR DESCRIPTION
The renewal path had no tests at all. Rotation, single-flight, the retry rule and
the storage contract were held up by comments — and both defects found this week
(logout revoking nothing, and the one below) came out of poking at a phone, not
out of the suite.

`auth.service.spec.ts` and `token-storage.spec.ts` are new;
`auth.interceptor.spec.ts` gains the cases it lacked. 73 → 92 tests.

The ones worth naming:

- **The pair that gets stored is the rotated one**, not the one that was sent.
  Keeping the old refresh token looks identical to success until the next
  renewal silently kills the session.
- **Three requests that expire together spend exactly one refresh token.**
  Rotation makes this mandatory: a second in-flight refresh would present a token
  the first one just revoked, and log out a perfectly valid session.
- **A 403 tears the session down without renewing** — a credential lacking an
  ability does not gain it by renewing.
- **No token reaches `localStorage`, `sessionStorage` or cookies**, checked by
  scanning every key rather than the ones we happen to know about: the failure
  that matters is the one written under a name nobody anticipated.

## One test is pending on purpose

The client is specified to log out when a request retried after a refresh is
rejected again (`identity/renovacion-de-sesion`, scenario "El reintento vuelve a
fallar"). **It does not.**

`handle401` calls `next(retried)` from inside the observable the outer
`catchError` returns, and RxJS does not route those errors back into that
`catchError`. The `RETRIED` branch is therefore unreachable, and the comment
above it describes something that never happens.

The half that protects the user still holds — no second refresh, and the error
reaches the caller, both covered by a passing test. What is missing is the
teardown: the app keeps a session the server already rejects, the UI still looks
authenticated, and every request answers 401 with nothing to resolve it.

Deleting the test would hide it; asserting the current behaviour would bless it.
It stays visible as `pending` with the reason written out, until a change fixes
it. This work adds coverage and does not change behaviour.

## Not done, and why

A test that the platform check in `main.ts` selects the right storage
implementation. It is a ternary inside the bootstrap call with no seam to test —
importing `main.ts` boots the whole app — and creating one means changing
production code, which this explicitly does not. The contract both
implementations must honour *is* covered, and so is the rule that neither writes
to browser storage. What is left uncovered is that one line.

## Verified on the device

OPPO CPH1941, Android 11. Session survives `am force-stop` and relaunch; logging
out empties the store; authenticated requests leave as `Dalvik/2.1.0` (the native
HTTP layer) while the public catalogue GET leaves as `Mozilla/… wv` (the WebView).

A note for anyone repeating that: the first pass gave a false negative — the log
showed both keys written and then removed seven seconds later, with a logout
nobody asked for. That was my automation finding a stale "Cerrar sesión" button
left in the DOM from the previous session's profile page. Kill the app between
passes rather than reusing the page.

Applies groups 5-8 of the OpenSpec change `renovacion-de-token-en-la-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDCHFEgvSUE67MFyb6XEN5
